### PR TITLE
Sinatra環境を作る

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ruby:3.0.2
+
+ENV APP_ROOT=/src
+
+RUN set -ex
+
+RUN apt-get update -qq
+RUN mkdir $APP_ROOT
+
+WORKDIR $APP_ROOT
+ADD ./Gemfile $APP_ROOT/Gemfile
+ADD ./Gemfile.lock $APP_ROOT/Gemfile.lock
+RUN bundle install -j4

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+source "https://rubygems.org"
+
+git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
+
+gem "sinatra"
+gem 'sinatra-contrib'
+gem 'webrick'
+gem "rake"
+gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,39 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    multi_json (1.15.0)
+    mustermann (1.1.1)
+      ruby2_keywords (~> 0.0.1)
+    rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
+    rack-test (1.1.0)
+      rack (>= 1.0, < 3)
+    rake (13.0.6)
+    ruby2_keywords (0.0.5)
+    sinatra (2.1.0)
+      mustermann (~> 1.0)
+      rack (~> 2.2)
+      rack-protection (= 2.1.0)
+      tilt (~> 2.0)
+    sinatra-contrib (2.1.0)
+      multi_json
+      mustermann (~> 1.0)
+      rack-protection (= 2.1.0)
+      sinatra (= 2.1.0)
+      tilt (~> 2.0)
+    tilt (2.0.10)
+    webrick (1.7.0)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rack-test
+  rake
+  sinatra
+  sinatra-contrib
+  webrick
+
+BUNDLED WITH
+   2.2.22

--- a/app.rb
+++ b/app.rb
@@ -1,0 +1,6 @@
+require 'sinatra'
+require 'sinatra/reloader'
+
+get '/' do
+  'Hello world!'
+end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  app:
+    build: .
+    tty: true
+    stdin_open: true
+    command: /bin/bash -c "bundle exec ruby app.rb -o 0.0.0.0"
+    volumes:
+      - .:/src
+    ports:
+      - "4567:4567"


### PR DESCRIPTION
ref https://github.com/challecara/git-training/issues/1

Ruby 3.0.2 (現時点での最新) で動作するSinatra環境を、Dockerで構築してみた。
docker-compose無しでもいいが、volumeなど色々オプション渡してDockerを起動するハードルを考えると、この方が良さそうな感じがする。