### PR TITLE
GitHub Actionsに除外するpathを追加

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -6,6 +6,9 @@ on:
       - opened
       - synchronize
       - reopened
+    paths-ignore:
+      - 'doc/images/**'
+      - '**.md'
 
 jobs:
   test:


### PR DESCRIPTION
`paths-ignore` に一致するファイルのみ更新された場合にはテストが実行されないようにした