### PR TITLE
GitHub公式サイトドキュメントのURLを修正する

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Git/GitHubを学ぶための資料やサンプルアプリを作成する場所�
 
 この演習では、サンプルのWebアプリケーションに簡単な機能を追加します。
 
-機能の追加は、[GitHub flow](https://guides.github.com/introduction/flow/) に沿って行います。
+機能の追加は、[GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow) に沿って行います。
 
 ### 内容
 

--- a/doc/clone.md
+++ b/doc/clone.md
@@ -1,6 +1,6 @@
 ## リポジトリをクローンする
 
-リポジトリのクローンの仕方は、[GitHub 公式ドキュメント](https://docs.github.com/ja/github/creating-cloning-and-archiving-repositories/cloning-a-repository-from-github/cloning-a-repository) を参照してください。
+リポジトリのクローンの仕方は、[GitHub 公式ドキュメント](https://docs.github.com/ja/repositories/creating-and-managing-repositories/cloning-a-repository) を参照してください。
 
 公式ドキュメント内では、`octocat/Spoon-Knife ` リポジトリをクローンしていますが、今回はチームメンバーの 1 人がフォークしたリポジトリをクローンします。
 ここではフォークしたメンバーを `zu-min` として説明します。

--- a/doc/fork.md
+++ b/doc/fork.md
@@ -1,6 +1,6 @@
 ## リポジトリをフォークする
 
-リポジトリのフォークの仕方は、[GitHub公式ドキュメント](https://docs.github.com/ja/github/getting-started-with-github/quickstart/fork-a-repo) を参照してください。
+リポジトリのフォークの仕方は、[GitHub公式ドキュメント](https://docs.github.com/ja/get-started/quickstart/fork-a-repo) を参照してください。
 
 公式ドキュメント内では、`octocat/Spoon-Knife ` リポジトリをフォークしていますが、今回は演習で使う `challecara/git-training` リポジトリをフォークします。
 
@@ -11,6 +11,6 @@ __フォークはチームメンバーの1人だけが行います。__
 チームメンバーをコラボレーターにすることで、フォークしたリポジトリに書き込み等の権限が付与され、ソースコードのプッシュなどができるようになります。
 
 コラボレーターへの招待の仕方は、
-[GitHub公式ドキュメント](https://docs.github.com/ja/github/setting-up-and-managing-your-github-user-account/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository) を参照してください。
+[GitHub公式ドキュメント](https://docs.github.com/ja/account-and-profile/setting-up-and-managing-your-personal-account-on-github/managing-access-to-your-personal-repositories/inviting-collaborators-to-a-personal-repository) を参照してください。
 
 また、演習でIssueを利用するので、フォークしたリポジトリの `Settings -> Features` にある、Issueのチェックボックスをオンにしておきましょう。

--- a/doc/issue.md
+++ b/doc/issue.md
@@ -1,6 +1,6 @@
 ## Issueを作成する
 
-Issueの作成方法は、[GitHubの公式ドキュメント](https://docs.github.com/ja/issues/tracking-your-work-with-issues/creating-issues/creating-an-issue) を参照してください
+Issueの作成方法は、[GitHubの公式ドキュメント](https://docs.github.com/ja/issues/tracking-your-work-with-issues/creating-an-issue) を参照してください
 
 ## Issue例
 今回は、新規機能を追加するIssueを作成するので、どういう機能を作成して、どのような動作をすることを期待するのかを書くことを心がけましょう。

--- a/doc/review_merge.md
+++ b/doc/review_merge.md
@@ -1,6 +1,6 @@
 ## レビューとマージ
 ### レビューをする
-レビュー機能については、[GitHub公式ドキュメント](https://docs.github.com/ja/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests) を参照してください。
+レビュー機能については、[GitHub公式ドキュメント](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests) を参照してください。
 
 修正して欲しい部分があったり、よくわからない部分があるときは、はコメントしましょう。
 
@@ -8,7 +8,7 @@
 
 ### マージをする
 マージの仕方は、
-[GitHub公式ドキュメント](https://docs.github.com/ja/github/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request) を参照してください。
+[GitHub公式ドキュメント](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/merging-a-pull-request) を参照してください。
 
 今回は、通常のマージをするので、 SquashやRebaseは選択せずに、そのままMerge pull requestボタンを押します。
 
@@ -19,6 +19,6 @@
 
 今回は、チームメンバー各々のGitHub IDのエンドポイントを追加していくので、全員のエンドポイントが残っていくのが正しい形なはずです。
 
-コンフリクト解消の仕方は、[GitHub公式ドキュメント](https://docs.github.com/ja/github/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github) を参照してください。
+コンフリクト解消の仕方は、[GitHub公式ドキュメント](https://docs.github.com/ja/pull-requests/collaborating-with-pull-requests/addressing-merge-conflicts/resolving-a-merge-conflict-on-github) を参照してください。
 
 GitHub上でもコンフリクトの解消はできますが、ローカルでもコンフリクト解消は可能で、マージ元ブランチに、マージ先ブランチをマージすることで解消することができます。


### PR DESCRIPTION
各種公式ドキュメントのURLが変更されていたので修正する。
PRについては、https://github.com/challecara/git-training/pull/47 で対応